### PR TITLE
Returned balance dialog flow

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -1,29 +1,22 @@
-const {dialogflow, SignIn} = require('actions-on-google');
-const functions = require('firebase-functions');
+const { dialogflow, SignIn } = require("actions-on-google");
+const functions = require("firebase-functions");
 
-
-process.env.DEBUG = 'dialogflow:debug'; // enables lib debugging statements
+process.env.DEBUG = "dialogflow:debug"; // enables lib debugging statements
 
 //YNAB - Change to use OAuth
 const ynab = require("ynab");
-// const accessToken =
-//   "0ac5d0e19930544fab97a568a6f4bda90bed5c02a8e1bd3c712c88814377aa4f";
 
+const app = dialogflow({ debug: true }); //is this redundant with line 4
 
-const app = dialogflow({
-  // gotten from YNAB OAuth Application
-  //clientId: '2922732bc9578566f020a9af459bca17a1d261ec8ebff0e0d4c2d3300c2888a6',
-});
-
-app.intent('Default Welcome Intent', (conv) => {
-  conv.ask(`What would you like me to do?`);
+app.intent("Default Welcome Intent", conv => {
+  conv.ask(`What information can I get for you today?`);
   // Complete your fulfillment logic and
   // send a response when the function is done executing
 });
 
-//Given a nameKey (category), search an array of objects for an object with the name of nameKey and return that object. 
-function search(nameKey, myArray){
-  for (var i=0; i < myArray.length; i++) {
+//Given a nameKey (category), search an array of objects for an object with the name of nameKey and return that object.
+function search(nameKey, myArray) {
+  for (var i = 0; i < myArray.length; i++) {
     if (myArray[i].name == nameKey) {
       return myArray[i];
     }
@@ -31,19 +24,20 @@ function search(nameKey, myArray){
 }
 //This intent is triggered by giving a category. It fetches all the budget categories from the default budget for the current month.
 //The returned categories are parsed down to the name, balance, and budgeted amount (we may not need this). We then use a search function
-//to search for the category name passed in and return an object (or objects) that have the same name. We then speak the category name and balance. 
-app.intent('get balance', (conv, { categories }) => {
-  
-  //We have to instantiate the new YNAB API after the OAuth token has been stored in conv.user.raw.accessToken. 
+//to search for the category name passed in and return an object (or objects) that have the same name. We then speak the category name and balance.
+app.intent("get balance", (conv, { categories }) => {
+  //We have to instantiate the new YNAB API after the OAuth token has been stored in conv.user.raw.accessToken.
   const ynabAPI = new ynab.API(conv.user.raw.accessToken);
 
-  if(!conv.data.balances) {
-  return ynabAPI.months.getBudgetMonth("default", "current")
-  .then(r => {
-    const ynabCategories = r.data.month.categories;
-    //conv.data.balances will store all the budget information will in the conversation. Use this to check if the data has already been fetched.
-    conv.data.balances = ynabCategories.map(c => {
-      return {
+  //Leave the if/else commented out for now. This way we force a fetch each time. This let's us update our information between requests. Eventually
+  //this should be a lamda request. 
+
+  // if (!conv.data.balances) {
+    return ynabAPI.months.getBudgetMonth("default", "current").then(r => {
+      const ynabCategories = r.data.month.categories;
+      //conv.data.balances will store all the budget information will in the conversation. Use this to check if the data has already been fetched.
+      conv.data.balances = ynabCategories.map(c => {
+        return {
           name: c.name.toLowerCase(),
           balance: ynab.utils
             .convertMilliUnitsToCurrencyAmount(c.balance, 2)
@@ -53,14 +47,35 @@ app.intent('get balance', (conv, { categories }) => {
             .toFixed(2)
         };
       });
-      const categoryObj = search(categories, conv.data.balances); 
-      conv.ask(`You have $${categoryObj.balance} remaining in your ${categoryObj.name} budget`);
+      const categoryObj = search(categories, conv.data.balances);
+      if (categoryObj.balance === categoryObj.budgeted) {
+        conv.ask(
+          `You have all $${
+            categoryObj.budgeted
+          } of your ${categoryObj.name} budget remaining.`
+        );
+      } else {
+        if (categoryObj.balance >= 0) {
+          conv.ask(
+            `You have $${categoryObj.balance} remaining of $${
+              categoryObj.budgeted
+            } budgeted for ${categoryObj.name}.`
+          );
+        } else {
+          conv.ask(`You are over your ${categoryObj.name} budget by $${-categoryObj.balance}`);
+        }
+      }
     });
-  } else {
-    //Find in the logs if a second request uses the stored budget or fetches new data
-    const categoryObj = search(categories, conv.data.balances); 
-    conv.ask(`You have $${categoryObj.balance} remaining in your ${categoryObj.name} budget`);
-  }
+  // } else {
+  //   //Find in the logs if a second request uses the stored budget or fetches new data.
+  //   //If we're adding new transactions this will have to be removed or we'll need to use delta requests.
+  //   const categoryObj = search(categories, conv.data.balances);
+  //   conv.ask(
+  //     `You have $${categoryObj.balance} remaining in your ${
+  //       categoryObj.name
+  //     } budget`
+  //   );
+  // }
 });
 
 // if we want to move sign in from the start of the Action we will have to use somthing like this.
@@ -68,8 +83,5 @@ app.intent('get balance', (conv, { categories }) => {
 // app.intent('Start Signin', (conv) => {
 //     conv.ask(new SignIn('To get your account details'));
 //   });
-    
 
 exports.dialogflowFirebaseFulfillment = functions.https.onRequest(app);
-
-

--- a/functions/index.js
+++ b/functions/index.js
@@ -6,14 +6,14 @@ process.env.DEBUG = 'dialogflow:debug'; // enables lib debugging statements
 
 //YNAB - Change to use OAuth
 const ynab = require("ynab");
-const accessToken =
-  "0ac5d0e19930544fab97a568a6f4bda90bed5c02a8e1bd3c712c88814377aa4f";
-const ynabAPI = new ynab.API(accessToken);
+// const accessToken =
+//   "0ac5d0e19930544fab97a568a6f4bda90bed5c02a8e1bd3c712c88814377aa4f";
+
 
 const app = dialogflow({
-    // gotten from YNAB OAuth Application
-    //clientId: '2922732bc9578566f020a9af459bca17a1d261ec8ebff0e0d4c2d3300c2888a6',
-  });
+  // gotten from YNAB OAuth Application
+  //clientId: '2922732bc9578566f020a9af459bca17a1d261ec8ebff0e0d4c2d3300c2888a6',
+});
 
 app.intent('Default Welcome Intent', (conv) => {
   conv.ask(`What would you like me to do?`);
@@ -21,23 +21,29 @@ app.intent('Default Welcome Intent', (conv) => {
   // send a response when the function is done executing
 });
 
+//Given a nameKey (category), search an array of objects for an object with the name of nameKey and return that object. 
 function search(nameKey, myArray){
   for (var i=0; i < myArray.length; i++) {
-      if (myArray[i].name == nameKey) {
-          return myArray[i];
-      }
+    if (myArray[i].name == nameKey) {
+      return myArray[i];
+    }
   }
 }
-
+//This intent is triggered by giving a category. It fetches all the budget categories from the default budget for the current month.
+//The returned categories are parsed down to the name, balance, and budgeted amount (we may not need this). We then use a search function
+//to search for the category name passed in and return an object (or objects) that have the same name. We then speak the category name and balance. 
 app.intent('get balance', (conv, { categories }) => {
-  //Currently does not use OAuth
-  //Replace the first parameter with the budgetId - will need to fetch it or use "default" is using OAuth
- 
-  return ynabAPI.months.getBudgetMonth("7f7e5fce-4f83-44ac-87d0-179b16a180d3", "current")
-    .then(r => {
-      const ynabCategories = r.data.month.categories;
-      conv.data.balances = ynabCategories.map(c => {
-        return {
+  
+  //We have to instantiate the new YNAB API after the OAuth token has been stored in conv.user.raw.accessToken. 
+  const ynabAPI = new ynab.API(conv.user.raw.accessToken);
+
+  if(!conv.data.balances) {
+  return ynabAPI.months.getBudgetMonth("default", "current")
+  .then(r => {
+    const ynabCategories = r.data.month.categories;
+    //conv.data.balances will store all the budget information will in the conversation. Use this to check if the data has already been fetched.
+    conv.data.balances = ynabCategories.map(c => {
+      return {
           name: c.name.toLowerCase(),
           balance: ynab.utils
             .convertMilliUnitsToCurrencyAmount(c.balance, 2)
@@ -48,8 +54,13 @@ app.intent('get balance', (conv, { categories }) => {
         };
       });
       const categoryObj = search(categories, conv.data.balances); 
-      conv.close(`You have ${categoryObj.balance} remaining in your ${categoryObj.name} budget`);
+      conv.ask(`You have $${categoryObj.balance} remaining in your ${categoryObj.name} budget`);
     });
+  } else {
+    //Find in the logs if a second request uses the stored budget or fetches new data
+    const categoryObj = search(categories, conv.data.balances); 
+    conv.ask(`You have $${categoryObj.balance} remaining in your ${categoryObj.name} budget`);
+  }
 });
 
 // if we want to move sign in from the start of the Action we will have to use somthing like this.


### PR DESCRIPTION
When a budget is return it will now use different syntax based on if the balance remaining is positive, negative, or equal to the budget. 

Please test locally with:
1. A category with a positive balance
2. A category with a negative balance
3. A category where the balance and the budget are equal

This does not resolve the issue. If acceptable, please merge the code and leave the issue open. Additional intents and the welcome still need dialog revision. 

Note: The if/else using conv.data.balances that determines if new data should be fetched has been commented out to allow me to change my budgets and fetch new data without leaving the conversation. If possible, the requests should be changed to delta requests. 