### PR TITLE
Added an error catch to the balance request

### DIFF
--- a/functions/index.js
+++ b/functions/index.js
@@ -74,7 +74,10 @@ app.intent("get balance", (conv, { categories }) => {
         `I'm sorry, I couldn't find a category called ${categories}. Do you want to check another balance?`
       );
     }
-  });
+  })
+  .catch(e => {
+      conv.ask(`There was an error fetching your information. Please try again later. Do you want to check another balance?`);
+    });
 });
 
 exports.dialogflowFirebaseFulfillment = functions.https.onRequest(app);


### PR DESCRIPTION
To test the error catching remove "default" from `return ynabAPI.months.getBudgetMonth("default", "current")` on Line 30 to purposefully throw an error. 

The error is returned as an object that is not displayed to the user and is not currently stored anywhere. I'll do some research on if the error is caught and logged into the Actions console or if we need to handle it. 

Close #33 